### PR TITLE
Add back class for navigation download icon

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -16,7 +16,7 @@
         </div>
 
         <div class="level-right">
-          <a class="level-item" href="/download/download_all">
+          <a class="level-item site-navigation-main__download" href="/download/download_all">
             Download All
             <span class="icon-download-light"></span>
           </a>


### PR DESCRIPTION
## Description

One of the previous PRs accidentally removed the class required for the navigation download icon to display correctly. This adds it back in.