### PR TITLE
Fix issue with ellipsis icon hover in categories component

### DIFF
--- a/app/assets/stylesheets/components/issues-categories.scss
+++ b/app/assets/stylesheets/components/issues-categories.scss
@@ -21,10 +21,6 @@
   top: 10px;
 }
 
-.issues-categories-chart__dropdown:hover .icon-ellipsis {
-  background-image: url('icon-ellipsis-hover.svg');
-}
-
 .issues-categories-chart__circle {
   background: #efefef;
   border-radius: 50%;


### PR DESCRIPTION
## Description

An old hover definition is preventing the ellipsis icon from displaying correctly within the issues categories component. Removing it fixes the issue.