### PR TITLE
Move downloads and details dropdown to separate component

### DIFF
--- a/app/assets/images/icon-details-light.svg
+++ b/app/assets/images/icon-details-light.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="6px" height="11px" viewBox="0 0 6 11" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 49.3 (51167) - http://www.bohemiancoding.com/sketch -->
+    <title>arrow-point-to-right</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Dashboard-(Overview)" transform="translate(-926.000000, -883.000000)" fill="#FFFFFF" fill-rule="nonzero">
+            <g id="Group-8" transform="translate(48.000000, 862.000000)">
+                <g id="Full-List-Button" transform="translate(767.000000, 9.000000)">
+                    <g id="arrow-point-to-right" transform="translate(114.000000, 17.500000) scale(-1, 1) rotate(-180.000000) translate(-114.000000, -17.500000) translate(111.000000, 12.000000)">
+                        <path d="M5.78412817,6.04455656 L1.25827398,10.774235 C0.970374986,11.075255 0.503596117,11.075255 0.215836891,10.774235 C-0.0719456302,10.4734827 -0.0719456302,9.98569151 0.215836891,9.6849636 L4.22051912,5.49992088 L0.215953364,1.31502422 C-0.0718291568,1.01415025 -0.0718291568,0.526407722 0.215953364,0.225655476 C0.503735885,-0.0752184921 0.97049146,-0.0752184921 1.25839045,0.225655476 L5.78424464,4.95540692 C5.9281359,5.10585608 6,5.30282762 6,5.49989654 C6,5.69706283 5.92799613,5.89418044 5.78412817,6.04455656 Z" id="Shape"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/dropdowns.scss
+++ b/app/assets/stylesheets/dropdowns.scss
@@ -36,7 +36,8 @@
   color: $white !important;
 }
 
-.dropdown-menu-dark .icon-download-light {
+.dropdown-menu-dark .icon-download-light,
+.dropdown-menu-dark .icon-details-light {
   display: inline-block;
   position: absolute;
   right: 15px;

--- a/app/assets/stylesheets/icons.scss
+++ b/app/assets/stylesheets/icons.scss
@@ -21,6 +21,15 @@ $icon-hover-colour: #6285a7;
   width: 16px;
 }
 
+.icon-details-light {
+  background-position: center;
+  background-image: image-url('icon-details-light.svg');
+  background-repeat: no-repeat;
+  background-size: contain;
+  height: 16px;
+  width: 16px;
+}
+
 .icon-ellipsis {
   background-image: image-url('icon-ellipsis.svg');
   background-position: center;

--- a/app/javascript/components/IssuesCategoriesChart.vue
+++ b/app/javascript/components/IssuesCategoriesChart.vue
@@ -3,17 +3,7 @@
     <h2>{{title}}</h2>
 
     <div class="dropdown is-right is-hoverable issues-categories-chart__dropdown">
-      <div class="dropdown-trigger icon-ellipsis"></div>
-
-      <div class="dropdown-menu dropdown-menu-dark" role="menu">
-        <div class="dropdown-content">
-          <a href="#" class="dropdown-item">
-            Download Issues
-
-            <span class="icon-download-light"></span>
-          </a>
-        </div>
-      </div>
+      <component-links :download="links.download" :details="links.details"></component-links>
     </div>
 
     <div class="issues-categories-chart__circle">
@@ -23,10 +13,20 @@
 </template>
 
 <script>
+import ComponentLinks from '../elements/ComponentLinks'
+
 export default {
+  components: {
+    ComponentLinks
+  },
   props: ['title', 'value'],
   data () {
-    return {}
+    return {
+      links: {
+        details: '#',
+        download: '#'
+      }
+    }
   }
 }
 </script>

--- a/app/javascript/components/IssuesTaxonomies.vue
+++ b/app/javascript/components/IssuesTaxonomies.vue
@@ -35,17 +35,7 @@
             </div>
             <div class="level-right">
               <div class="level-item issues-taxonomies__list-dropdown dropdown is-right is-hoverable">
-                <div class="dropdown-trigger icon-ellipsis"></div>
-
-                <div class="dropdown-menu dropdown-menu-dark" role="menu">
-                  <div class="dropdown-content">
-                    <a href="#" class="dropdown-item">
-                      Download Issues
-
-                      <span class="icon-download-light"></span>
-                    </a>
-                  </div>
-                </div>
+                <component-links :download="links.download" :details="links.details"></component-links>
               </div>
             </div>
           </li>
@@ -56,12 +46,21 @@
 </template>
 
 <script>
+import ComponentLinks from '../elements/ComponentLinks'
+
 export default {
+  components: {
+    ComponentLinks
+  },
   props: ['taxonomies'],
   data () {
     return {
       colours: ['#3c526a', '#088ba5', '#00a2d0', '#3aa18e', '#58bc8a', '#91c352', '#b4c92c', '#d5ec3a'],
-      textColours: ['#fff', 'inherit', 'inherit', 'inherit', 'inherit', 'inherit', 'inherit', 'inherit']
+      textColours: ['#fff', 'inherit', 'inherit', 'inherit', 'inherit', 'inherit', 'inherit', 'inherit'],
+      links: {
+        details: '#',
+        download: '#'
+      }
     }
   },
   methods: {

--- a/app/javascript/components/TopCommodities.vue
+++ b/app/javascript/components/TopCommodities.vue
@@ -27,17 +27,7 @@
             </div>
             <div class="level-right">
               <div class="level-item top-commodities__list-dropdown dropdown is-right is-hoverable">
-                <div class="dropdown-trigger icon-ellipsis"></div>
-
-                <div class="dropdown-menu dropdown-menu-dark" role="menu">
-                  <div class="dropdown-content">
-                    <a href="#" class="dropdown-item">
-                      Download Issues
-
-                      <span class="icon-download-light"></span>
-                    </a>
-                  </div>
-                </div>
+                <component-links :download="links.download" :details="links.details"></component-links>
               </div>
             </div>
           </li>
@@ -60,12 +50,21 @@
 </template>
 
 <script>
+import ComponentLinks from '../elements/ComponentLinks'
+
 export default {
+  components: {
+    ComponentLinks
+  },
   props: ['commodities'],
   data () {
     return {
       colours: ['#3c526a', '#088ba5', '#00a2d0', '#3aa18e', '#b3c82b'],
-      textColours: ['#fff', 'inherit', 'inherit', 'inherit', 'inherit']
+      textColours: ['#fff', 'inherit', 'inherit', 'inherit', 'inherit'],
+      links: {
+        details: '#',
+        download: '#'
+      }
     }
   }
 }

--- a/app/javascript/components/TopCountries.vue
+++ b/app/javascript/components/TopCountries.vue
@@ -34,17 +34,7 @@
             </div>
             <div class="level-right">
               <div class="level-item top-countries__list-dropdown dropdown is-right is-hoverable">
-                <div class="dropdown-trigger icon-ellipsis"></div>
-
-                <div class="dropdown-menu dropdown-menu-dark" role="menu">
-                  <div class="dropdown-content">
-                    <a href="#" class="dropdown-item">
-                      Download Issues
-
-                      <span class="icon-download-light"></span>
-                    </a>
-                  </div>
-                </div>
+                <component-links :download="links.download" :details="links.details"></component-links>
               </div>
             </div>
           </li>
@@ -60,14 +50,23 @@ import Datamap from 'datamaps'
 import iso2toiso3 from '../helpers/iso2-to-iso3'
 import countries from '../data/countries';
 
+import ComponentLinks from '../elements/ComponentLinks'
+
 export default {
+  components: {
+    ComponentLinks
+  },
   props: ['export', 'import'],
   data () {
     return {
       mode: 'export',
       colours: ['#3c526a', '#088ba5', '#00a2d0', '#3aa18e', '#b3c82b'],
       getMap: null,
-      activeCountry: null
+      activeCountry: null,
+      links: {
+        details: '#',
+        download: '#'
+      }
     }
   },
   methods: {

--- a/app/javascript/components/TopSpecies.vue
+++ b/app/javascript/components/TopSpecies.vue
@@ -30,17 +30,7 @@
           <td>{{species.appendix}}</td>
           <td>
             <div class="level-item top-species__dropdown dropdown is-right is-hoverable">
-              <div class="dropdown-trigger icon-ellipsis"></div>
-
-              <div class="dropdown-menu dropdown-menu-dark" role="menu">
-                <div class="dropdown-content">
-                  <a href="#" class="dropdown-item">
-                    Download Issues
-
-                    <span class="icon-download-light"></span>
-                  </a>
-                </div>
-              </div>
+              <component-links :download="links.download" :details="links.details"></component-links>
             </div>
           </td>
         </tr>
@@ -50,10 +40,20 @@
 </template>
 
 <script>
+import ComponentLinks from '../elements/ComponentLinks'
+
 export default {
+  components: {
+    ComponentLinks
+  },
   props: ['species'],
   data () {
-    return {}
+    return {
+      links: {
+        details: '#',
+        download: '#'
+      }
+    }
   }
 }
 </script>

--- a/app/javascript/elements/ComponentLinks.vue
+++ b/app/javascript/elements/ComponentLinks.vue
@@ -4,7 +4,7 @@
 
     <div class="dropdown-menu dropdown-menu-dark" role="menu">
       <div class="dropdown-content">
-        <a v-if="details" :href="download" class="dropdown-item">
+        <a v-if="details" :href="details" class="dropdown-item">
           View Details
           <span class="icon-details-light"></span>
         </a>

--- a/app/javascript/elements/ComponentLinks.vue
+++ b/app/javascript/elements/ComponentLinks.vue
@@ -1,0 +1,27 @@
+<template>
+  <div>
+    <div class="dropdown-trigger icon-ellipsis"></div>
+
+    <div class="dropdown-menu dropdown-menu-dark" role="menu">
+      <div class="dropdown-content">
+        <a v-if="details" :href="download" class="dropdown-item">
+          View Details
+          <span class="icon-details-light"></span>
+        </a>
+        <a v-if="download" :href="download" class="dropdown-item">
+          Download Issues
+          <span class="icon-download-light"></span>
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['download', 'details'],
+  data () {
+    return {}
+  }
+}
+</script>


### PR DESCRIPTION
## Description

Moves the downloads and details dropdown code into a separate component utilising properties for link definition.

## Known issues

* Links are hard-coded as properties within each parent component

## Screenshots

![image](https://user-images.githubusercontent.com/22612/42813309-78c3642e-89b8-11e8-8935-9d8432094ff8.png)
