### PR TITLE
Update map when props change

### DIFF
--- a/app/javascript/components/TopCountries.vue
+++ b/app/javascript/components/TopCountries.vue
@@ -69,6 +69,14 @@ export default {
       }
     }
   },
+  watch: {
+    export() {
+      this.reloadMap()
+    },
+    import() {
+      this.reloadMap()
+    }
+  },
   methods: {
     getModeData() {
       return (this.mode === 'export') ? this.export : this.import


### PR DESCRIPTION
## Description

The map doesn't update when the year is changed until you change the type from importer or exporter. This has been fixed by refreshing the map when the input props change.