### PR TITLE
Filter search page data

### DIFF
--- a/app/controllers/api/v1/sapi_controller.rb
+++ b/app/controllers/api/v1/sapi_controller.rb
@@ -11,7 +11,8 @@ class Api::V1::SapiController < ApplicationController
   private
 
   def sapi_params
-    params.require(:sapi).permit(:call, :grouping, :year, :compliance_type, :user_id, :page)
+    params.require(:sapi).permit(:call, :grouping, :year, :compliance_type,
+                                 :filter, :id, :user_id, :page, :query)
   end
 
   def authenticate_user

--- a/app/controllers/api/v1/sapi_controller.rb
+++ b/app/controllers/api/v1/sapi_controller.rb
@@ -8,6 +8,19 @@ class Api::V1::SapiController < ApplicationController
     render json: @data.to_json
   end
 
+  def countries
+    render json: ShipmentsApiRetriever.call(:countries)
+  end
+
+  def terms
+    render json: ShipmentsApiRetriever.call(:terms)
+  end
+
+  def species_autocomplete
+    query = { taxon_concept_query: sapi_params[:query] || '' }
+    render json: ShipmentsApiRetriever.call(:species_autocomplete, query)
+  end
+
   private
 
   def sapi_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,7 @@ Rails.application.routes.draw do
   resources :search, only: [:index]
 
   get 'api/v1/sapi', to: 'api/v1/sapi#index', as: 'api/v1/sapi'
+  get 'api/v1/sapi/countries', to: 'api/v1/sapi#countries', as: 'api/v1/sapi/countries'
+  get 'api/v1/sapi/terms', to: 'api/v1/sapi#terms', as: 'api/v1/sapi/terms'
+  get 'api/v1/sapi/species_autocomplete', to: 'api/v1/sapi#species_autocomplete', as: 'api/v1/sapi/species_autocomplete'
 end

--- a/lib/modules/shipments_api_retriever.rb
+++ b/lib/modules/shipments_api_retriever.rb
@@ -3,16 +3,16 @@ module ShipmentsApiRetriever
   AVAILABLE_TYPES = ['category', 'importing', 'exporting', 'commodity', 'species', 'taxonomy']
 
   def self.api_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'],
+    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/shipments',
                             headers: header,
                             query: { compliance_type: params[:compliance_type],
                                      time_range_start: params[:year] || 2012, time_range_end: params[:year] || 2016,
-                                     page: params[:page] || 1 , per_page: 100_00 })
+                                     page: params[:page] || 1, per_page: 100_00 })
     JSON.parse(response.body)
   end
 
   def self.grouped_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/grouped',
+    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/shipments/grouped',
                             headers: header,
                             query: { group_by: sanitise_type(params[:grouping]) })
     data = JSON.parse(response.body)
@@ -20,9 +20,31 @@ module ShipmentsApiRetriever
   end
 
   def self.search_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/search',
+    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/shipments/search',
                             headers: header,
-                            query: { year: params[:year] || 2012, group_by: params[:group] || 'exporting' })
+                            query: { year: params[:year] || 2012, group_by: params[:grouping] || 'exporting',
+                                     filter: params[:filter] || '', id: params[:id] || '',
+                                     page: params[:page] || 1 })
+    JSON.parse(response.body)
+  end
+
+  def self.species_autocomplete_call(params)
+    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/auto_complete_taxon_concepts',
+                            headers: header,
+                            query: { taxon_concept_query: params[:query] || '' })
+    JSON.parse(response.body)
+  end
+
+  def self.countries_call(_params)
+    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/geo_entities',
+                            headers: header,
+                            query: { geo_entity_types_set: 4 })
+    JSON.parse(response.body)
+  end
+
+  def self.terms_call(_params)
+    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/terms',
+                            headers: header)
     JSON.parse(response.body)
   end
 

--- a/lib/modules/shipments_api_retriever.rb
+++ b/lib/modules/shipments_api_retriever.rb
@@ -2,49 +2,51 @@ module ShipmentsApiRetriever
 
   AVAILABLE_TYPES = ['category', 'importing', 'exporting', 'commodity', 'species', 'taxonomy']
 
+  ENDPOINTS = {
+    shipments: 'shipments',
+    grouped: 'shipments/grouped',
+    search: 'shipments/search',
+    countries: 'geo_entities',
+    terms: 'terms',
+    species_autocomplete: 'auto_complete_taxon_concepts'
+  }
+
   def self.api_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/shipments',
-                            headers: header,
-                            query: { compliance_type: params[:compliance_type],
-                                     time_range_start: params[:year] || 2012, time_range_end: params[:year] || 2016,
-                                     page: params[:page] || 1, per_page: 100_00 })
-    JSON.parse(response.body)
+    query = {
+      compliance_type: params[:compliance_type],
+      time_range_start: params[:year] || 2012,
+      time_range_end: params[:year] || 2016,
+      page: params[:page] || 1,
+      per_page: 100_00
+    }
+
+    call(:shipments, query)
   end
 
   def self.grouped_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/shipments/grouped',
-                            headers: header,
-                            query: { group_by: sanitise_type(params[:grouping]) })
-    data = JSON.parse(response.body)
+    query = { group_by: sanitise_type(params[:grouping]) }
+
+    data = call(:grouped, query)
     data['shipments'] || data
   end
 
   def self.search_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/shipments/search',
-                            headers: header,
-                            query: { year: params[:year] || 2012, group_by: params[:grouping] || 'exporting',
-                                     filter: params[:filter] || '', id: params[:id] || '',
-                                     page: params[:page] || 1 })
-    JSON.parse(response.body)
+    query = {
+      year: params[:year] || 2012,
+      group_by: params[:grouping] || 'exporting',
+      filter: params[:filter] || '',
+      id: params[:id] || '',
+      page: params[:page] || 1
+    }
+
+    call(:search, query)
   end
 
-  def self.species_autocomplete_call(params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/auto_complete_taxon_concepts',
-                            headers: header,
-                            query: { taxon_concept_query: params[:query] || '' })
-    JSON.parse(response.body)
-  end
+  def self.call(endpoint, query=nil)
+    return '' unless ENDPOINTS[endpoint]
 
-  def self.countries_call(_params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/geo_entities',
-                            headers: header,
-                            query: { geo_entity_types_set: 4 })
-    JSON.parse(response.body)
-  end
-
-  def self.terms_call(_params)
-    response = HTTParty.get(Rails.application.secrets['species_api_url'] + '/terms',
-                            headers: header)
+    url = "#{Rails.application.secrets['species_api_url']}/#{ENDPOINTS[endpoint]}"
+    response = HTTParty.get(url, headers: header, query: query)
     JSON.parse(response.body)
   end
 


### PR DESCRIPTION
This adds the endpoints for the autocompletion on the search page and the filter functionality (by id or by regexp). 

P.S.:  the species_api_url variable has been changed to taking into account the new endpoints. Change the .env file accordingly