### PR TITLE
Add tag to show which users are admins

### DIFF
--- a/app/javascript/AccountsPage.vue
+++ b/app/javascript/AccountsPage.vue
@@ -26,7 +26,12 @@
               <li v-else v-for="(user, index) in users" v-bind:key="index">
                 <div class="level">
                   {{user.email}}
-                  <button class="button is-white accounts__list-remove" v-on:click="onClickRemoveUser(user.id, user.email)">
+
+                  <span v-if="user.admin" class="tag is-medium">
+                    Admin
+                  </span>
+
+                  <button v-else class="button is-white accounts__list-remove" v-on:click="onClickRemoveUser(user.id, user.email)">
                     <span class="icon-remove"></span>
                     <span>Remove</span>
                   </button>


### PR DESCRIPTION
## Description

* Adds tag to show which users are admins
* Replaces "Remove" button for admin users so it's obvious that they can't be deleted

## Known issues

* None

## Screenshots

![2018-08-31 09_02_42-citescompliancetool](https://user-images.githubusercontent.com/22612/44900540-c0babe00-acfc-11e8-9d04-fee7963b9d7f.png)
