### PR TITLE
Feedback changes

### DIFF
--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -39,3 +39,9 @@ strong {
 p {
   margin-bottom: 14px;
 }
+
+ul {
+  list-style: disc;
+  margin: 20px;
+  padding-left: 20px;
+}

--- a/app/javascript/DashboardPage.vue
+++ b/app/javascript/DashboardPage.vue
@@ -150,7 +150,7 @@ export default {
 
       tableColumns: {
         exporting: {
-          headers: ['Country / Region', 'No. Transactions with issues', 'Total No. of Transactions', '% of Transactions with issues'],
+          headers: ['Country / Territory', 'No. Transactions with issues', 'Total No. of Transactions', '% of Transactions with issues'],
           keys: ['country', 'cnt', 'total_cnt', 'percentage']
         },
         commodity: {

--- a/app/javascript/SearchPage.vue
+++ b/app/javascript/SearchPage.vue
@@ -7,7 +7,7 @@
         <div class="level-left">
           <h2 class="level-item" :class="{active: (selectedCategory === 'exporting')}">
             <a v-on:click="changeCategory('exporting')">
-              Countries & Regions
+              Countries & Territories
             </a>
           </h2>
           <h2 class="level-item" :class="{active: (selectedCategory === 'species')}">
@@ -106,7 +106,7 @@ export default {
       tableData: [],
       tableColumns: {
         exporting: {
-          headers: ['Country / Region', 'No. Transactions with issues', 'Total No. of Transactions', '% of Transactions with issues'],
+          headers: ['Country / Territory', 'No. Transactions with issues', 'Total No. of Transactions', '% of Transactions with issues'],
           keys: ['country', 'cnt', 'total_cnt', 'percentage']
         },
         commodity: {

--- a/app/javascript/components/IssuesCategories.vue
+++ b/app/javascript/components/IssuesCategories.vue
@@ -7,7 +7,7 @@
 
       <div class="columns is-mobile">
         <div class="column is-one-third" v-for="(category, index) in values" :key="index">
-          <issues-categories-chart :title="category.issue_type" :value="category.value" :user="user" :year="year"></issues-categories-chart>
+          <issues-categories-chart :title="title(category.issue_type)" :value="category.value" :user="user" :year="year"></issues-categories-chart>
         </div>
       </div>
     </div>
@@ -26,6 +26,20 @@ export default {
   props: ['values', 'user', 'year'],
   data () {
     return {}
+  },
+
+  methods: {
+    title (issue_type) {
+      if(issue_type.match(/App/)) {
+        return 'Appendix I'
+      }
+      else if(issue_type.match(/Suspension/)) {
+        return 'Suspensions'
+      }
+      else {
+        return 'Quotas'
+      }
+    }
   }
 }
 </script>

--- a/app/javascript/components/IssuesChartPanel.vue
+++ b/app/javascript/components/IssuesChartPanel.vue
@@ -7,12 +7,12 @@
 
     <div class="issues-chart__panel-countries">
       <span>{{values.countriesReported}}</span>
-      <p>Countries reported</p>
+      <p>Parties reported</p>
     </div>
 
     <div class="issues-chart__panel-countries">
       <span>{{values.countriesYetToReport}}</span>
-      <p>Countries yet to report</p>
+      <p>Parties yet to report</p>
     </div>
 
     <div class="issues-chart__label">{{values.year}}</div>


### PR DESCRIPTION
From feedback in email:
(add s & space)
·        Suspensions
·        Appendix I
·        Quotas
 
Also – should be “Countries & Territories” under “Search”  and – for header once clicked - “Country / Territory” 
 
And within timeline on Dashboard – should read “Parties” not, Countries:
-        Countries reported à Parties reported
-        Countries yet to report  à Parties yet to report