### PR TITLE
feat: add a note to modals explaining how data is derived

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,9 @@ GEM
     marcel (0.3.2)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -298,4 +300,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/app/assets/stylesheets/modals.scss
+++ b/app/assets/stylesheets/modals.scss
@@ -19,10 +19,6 @@
   width: 960px;
 }
 
-.modal-content h2 {
-  margin-bottom: 1.5rem;
-}
-
 .modal-content .search-list {
   border: $tile-section-border;
 }

--- a/app/javascript/DashboardPage.vue
+++ b/app/javascript/DashboardPage.vue
@@ -75,6 +75,7 @@
       <div class="modal-content">
         <h1>{{tableName}}</h1>
         <h2>Issues currently reported in {{selectedYear}}</h2>
+        <p v-if="explanationText">{{explanationText}}</p>
         <search-list :columns="tableColumns[tableCategory]" :grouping="tableCategory" :year="selectedYear" per-page="8" :user="user" :in-modal="true"></search-list>
       </div>
       <button class="modal-close is-large button-full-list" aria-label="close" v-on:click="closeModal()"></button>
@@ -235,6 +236,17 @@ export default {
       }
 
       return
+    },
+
+    explanationText() {
+      switch (this.tableCategory) {
+        case 'exporting': case 'importing':
+          return 'Based on combining imports and exports as reported by both reporting Parties'
+        case 'species': case 'commodity':
+          return 'Based on combining importer- and exporter-reported data'
+        default:
+          return false
+      }
     }
   },
 


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/70

Adds additional text explaining the data shown in the modal tables

testing:

on dashboard, click the various modal buttons
![image](https://github.com/unepwcmc/cites-compliance-tool/assets/15033504/d7c916b6-b666-4849-aa4d-0a4e6dffc9a0)

Between the titles and the table you should see:
- "Based on combining imports and exports as reported by both reporting Parties" on the country modal
- "Based on combining importer- and exporter-reported data" on the commodity and species modals
