### PR TITLE
feat: change text on one statistic and remove another on charts

### DIFF
--- a/app/javascript/components/IssuesChartPanel.vue
+++ b/app/javascript/components/IssuesChartPanel.vue
@@ -7,12 +7,7 @@
 
     <div class="issues-chart__panel-countries">
       <span>{{values.countriesReported}}</span>
-      <p>Parties reported</p>
-    </div>
-
-    <div class="issues-chart__panel-countries">
-      <span>{{values.countriesYetToReport}}</span>
-      <p>Parties yet to report</p>
+      <p>Parties with issues reported</p>
     </div>
 
     <div class="issues-chart__label">{{values.year}}</div>


### PR DESCRIPTION
https://unep-wcmc.codebasehq.com/projects/cites-support-maintenance/tickets/68

Changes the wording on one statistic shown in the charts and deletes another

Testing:
on dashboard, select a year with data
the panels should show:
![image](https://github.com/unepwcmc/cites-compliance-tool/assets/15033504/5478e188-45b0-4c23-978c-7b218453d6fd)
